### PR TITLE
Comment out unused shield image links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@
 <p>
 <img src="https://img.shields.io/badge/Amazon_AWS-FF9900?style=for-the-badge&logo=amazonaws&logoColor=white&labelColor=FF9900"/>
 <img src="https://img.shields.io/badge/Google_Cloud-4285F4?style=for-the-badge&logo=google-cloud&logoColor=white&labelColor=4285F4"/>
-#<img src="https://img.shields.io/badge/Microsoft_Azure-0089D0?style=for-the-badge&logo=microsoft-azure&logoColor=white&labelColor=0089D0"/>
+<!-- <img src="https://img.shields.io/badge/Microsoft_Azure-0089D0?style=for-the-badge&logo=microsoft-azure&logoColor=white&labelColor=0089D0"/> -->
 </p>
 
 ### 🚀 **DevOps & Orchestration**
@@ -145,7 +145,7 @@
 <img src="https://img.shields.io/badge/Jenkins-D24939?style=for-the-badge&logo=Jenkins&logoColor=white&labelColor=D24939"/>
 <img src="https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform&logoColor=white&labelColor=7B42BC"/>
 <img src="https://img.shields.io/badge/Ansible-000000?style=for-the-badge&logo=ansible&logoColor=white&labelColor=EE0000"/>
-#<img src="https://img.shields.io/badge/GitLab_CI-FC6D26?style=for-the-badge&logo=gitlab&logoColor=white&labelColor=FC6D26"/>
+<!-- <img src="https://img.shields.io/badge/GitLab_CI-FC6D26?style=for-the-badge&logo=gitlab&logoColor=white&labelColor=FC6D26"/> -->
 </p>
 
 ### 💻 **Programming & Scripting**
@@ -154,7 +154,7 @@
 <img src="https://img.shields.io/badge/Python-FFD43B?style=for-the-badge&logo=python&logoColor=blue&labelColor=FFD43B"/>
 <img src="https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white&labelColor=339933"/>
 <img src="https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB&labelColor=20232A"/>
-#<img src="https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black&labelColor=F7DF1E"/>
+<!-- <img src="https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black&labelColor=F7DF1E"/> -->
 </p>
 
 ### 🗄️ **Databases & Storage**
@@ -169,15 +169,15 @@
 <p>
 <img src="https://img.shields.io/badge/Grafana-F2F4F9?style=for-the-badge&logo=grafana&logoColor=orange&labelColor=F2F4F9"/>
 <img src="https://img.shields.io/badge/Prometheus-000000?style=for-the-badge&logo=prometheus&labelColor=E6522C&logoColor=white"/>
-#<img src="https://img.shields.io/badge/Elastic_Search-005571?style=for-the-badge&logo=elasticsearch&logoColor=white&labelColor=005571"/>
-#<img src="https://img.shields.io/badge/Kibana-005571?style=for-the-badge&logo=Kibana&logoColor=white&labelColor=005571"/>
+<!-- <img src="https://img.shields.io/badge/Elastic_Search-005571?style=for-the-badge&logo=elasticsearch&logoColor=white&labelColor=005571"/>
+<img src="https://img.shields.io/badge/Kibana-005571?style=for-the-badge&logo=Kibana&logoColor=white&labelColor=005571"/> -->
 </p>
 
 ### 🌐 **Web Servers & Networking**
 <p>
 <img src="https://img.shields.io/badge/Nginx-009639?style=for-the-badge&logo=nginx&logoColor=white&labelColor=009639"/>
 <img src="https://img.shields.io/badge/Apache-D22128?style=for-the-badge&logo=Apache&logoColor=white&labelColor=D22128"/>
-#<img src="https://img.shields.io/badge/HAProxy-106da9?style=for-the-badge&logo=haproxy&logoColor=white&labelColor=106da9"/>
+<!-- <img src="https://img.shields.io/badge/HAProxy-106da9?style=for-the-badge&logo=haproxy&logoColor=white&labelColor=106da9"/> -->
 </p>
 
 ### 🔧 **Operating Systems**


### PR DESCRIPTION
Commented out several shield image links for cloud platforms, DevOps tools, programming languages, monitoring tools, and web servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README.md by commenting out multiple technology badge images including Azure, GitLab CI, JavaScript, Elastic Search, Kibana, and HAProxy. The document structure remains intact with badges hidden from display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->